### PR TITLE
12-byte IVs (#6)

### DIFF
--- a/omemo.h
+++ b/omemo.h
@@ -75,7 +75,7 @@
 #define NS_EME "urn:xmpp:eme:0"
 #define CIPHER_MODE_GCM 3562
 #define OMEMO_PAYLOAD_SECRET_LEN 16 // AES-128-GCM
-#define OMEMO_PAYLOAD_IV_LEN 16 // AES blocksize
+#define OMEMO_PAYLOAD_IV_LEN 12 // AES blocksize
 #define SIGNED_PRE_KEY_DAYS_TO_RENEW 7
 #define SIGNED_PRE_KEY_DAYS_TO_DELETE 30
 


### PR DESCRIPTION
The XEP-0384 0.3.0 does not specify the "IV" value and the 0.3.1 version has been missing before the 0.4.0 version.
All OMEMO 0.3.0 clients must send with 12-byte instead 16-byte IV.

This PR solves this problem, linked to #6.